### PR TITLE
Fix adns_upload_firmware(): release SPI bus after firmware upload.

### DIFF
--- a/Arduino Examples/PMW3360DM-Interrupt/PMW3360DM-Interrupt.ino
+++ b/Arduino Examples/PMW3360DM-Interrupt/PMW3360DM-Interrupt.ino
@@ -156,6 +156,10 @@ void adns_upload_firmware(){
     delayMicroseconds(15);
   }
 
+  adns_com_end();
+
+  delay(10);
+
   //Read the SROM_ID register to verify the ID before any other register reads or writes.
   adns_read_reg(SROM_ID);
 
@@ -164,8 +168,6 @@ void adns_upload_firmware(){
 
   // set initial CPI resolution
   adns_write_reg(Config1, 0x15);
-  
-  adns_com_end();
   }
 
 

--- a/Arduino Examples/PMW3360DM-polling/PMW3360DM-polling.ino
+++ b/Arduino Examples/PMW3360DM-polling/PMW3360DM-polling.ino
@@ -164,6 +164,10 @@ void adns_upload_firmware(){
     delayMicroseconds(15);
   }
 
+  adns_com_end();
+
+  delay(10);
+
   //Read the SROM_ID register to verify the ID before any other register reads or writes.
   adns_read_reg(SROM_ID);
 
@@ -172,8 +176,6 @@ void adns_upload_firmware(){
 
   // set initial CPI resolution
   adns_write_reg(Config1, 0x15);
-  
-  adns_com_end();
   }
 
 


### PR DESCRIPTION
The 10mS delay is arbitrarily choosen, it works for me with 1mS delay also, but not without a delay.